### PR TITLE
Fix install_entitlements.js script

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="com.jcesarmobile.filepicker"
-        version="1.2.1">
+        version="1.2.2">
 
   <name>File Picker</name>
   <author>jcesarmobile</author>

--- a/src/ios/hooks/install_entitlements.js
+++ b/src/ios/hooks/install_entitlements.js
@@ -13,7 +13,8 @@ var xcode = require('xcode'),
     throw new Error('This plugin expects the ios platform to exist.');
   }
 
-  var iosFolder = context.opts.cordova.project ? context.opts.cordova.project.root : path.join(context.opts.projectRoot, 'platforms/ios/');
+  var iosPlatform = path.join(context.opts.projectRoot, 'platforms/ios/');
+  var iosFolder = fs.existsSync(iosPlatform) ? iosPlatform : context.opts.projectRoot; 
   console.error("iosFolder: " + iosFolder);
 
   fs.readdir(iosFolder, function (err, data) {


### PR DESCRIPTION
Use `context.opts.projectRoot` parameter as it is available in both AppBuilder and Cordova CLI
